### PR TITLE
Separate downloading models to a util file

### DIFF
--- a/src/mlx_alt_text/cli.py
+++ b/src/mlx_alt_text/cli.py
@@ -12,16 +12,15 @@ from .generator import AltTextGenerator
     type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path),
 )
 @click.option(
+    "--model",
+    "-m",
+    help="The path to the model to use for generation. The exact snapshot must be specified as well.",
+)
+@click.option(
     "--prompt",
     "-p",
     default="Describe this image in detail for accessibility purposes",
     help="Custom prompt to use for generation",
-)
-@click.option(
-    "--model",
-    "-m",
-    default=DEFAULT_MODEL,
-    help="Model to use for generation, try 'mlx-community/SmolVLM-Instruct-bf16' or 'mlx-community/SmolVLM-256M-Instruct-4bit'",
 )
 @click.option(
     "--max-tokens",

--- a/src/mlx_alt_text/cli.py
+++ b/src/mlx_alt_text/cli.py
@@ -2,11 +2,21 @@ from pathlib import Path
 
 import click
 
-from .constants import *
+from .constants import DEFAULT_MAX_TOKENS, DEFAULT_TEMPERATURE
 from .generator import AltTextGenerator
+from .model_utils import download_model
 
 
-@click.command()
+@click.group(
+    invoke_without_command=True,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+def cli():
+    """MLX Alt-Text: Generate accessible image descriptions using local MLX models."""
+    pass
+
+
+@cli.command("generate")
 @click.argument(
     "image_path",
     type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path),
@@ -14,6 +24,7 @@ from .generator import AltTextGenerator
 @click.option(
     "--model",
     "-m",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
     help="The path to the model to use for generation. The exact snapshot must be specified as well.",
 )
 @click.option(
@@ -35,7 +46,7 @@ from .generator import AltTextGenerator
     help="Temperature for generation",
 )
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose output")
-def alt_text(image_path, prompt, model, max_tokens, temperature, verbose):
+def generate(image_path, prompt, model, max_tokens, temperature, verbose):
     """Generate alt-text for the provided iamge using local MLX models."""
     generator = AltTextGenerator(model, max_tokens, temperature)
     try:
@@ -48,8 +59,21 @@ def alt_text(image_path, prompt, model, max_tokens, temperature, verbose):
         raise click.Abort()
 
 
+@cli.command("download")
+@click.argument("model_name")
+@click.option("--verbose", "-v", is_flag=True, help="Enable verbose output")
+def download(model_name, verbose):
+    """Download a model for later use with the generate command."""
+    try:
+        path = download_model(model_name, verbose=verbose)
+        click.echo(f"Model successfully downloaded to: {path}")
+    except Exception as e:
+        click.echo(f"Error downloading model: {e}", err=True)
+        raise click.Abort()
+
+
 def main():
-    alt_text()
+    cli()
 
 
 if __name__ == "__main__":

--- a/src/mlx_alt_text/constants.py
+++ b/src/mlx_alt_text/constants.py
@@ -1,3 +1,2 @@
-DEFAULT_MODEL = "mlx-community/Qwen2-VL-2B-Instruct-4bit"
 DEFAULT_MAX_TOKENS = 100  # TODO experiment
 DEFAULT_TEMPERATURE = 0.2  # TODO experiment

--- a/src/mlx_alt_text/model_utils.py
+++ b/src/mlx_alt_text/model_utils.py
@@ -1,0 +1,31 @@
+from huggingface_hub import snapshot_download
+from huggingface_hub.utils.tqdm import disable_progress_bars
+
+
+def download_model(
+    model_name: str, verbose: bool = False, progress_bars: bool = True
+) -> str:
+    """Download a model for use with AltTextGenerator."""
+
+    if verbose:
+        print(f"Downloading model: {model_name}...")
+
+    if not progress_bars:
+        disable_progress_bars()
+
+    model_path = snapshot_download(
+        repo_id=model_name,
+        allow_patterns=[
+            "*.json",
+            "*.safetensors",
+            "*.py",
+            "tokenizer.model",
+            "*.tiktoken",
+            "*.txt",
+        ],
+    )
+
+    if verbose:
+        print(f"Model downloaded to: {model_path}")
+
+    return model_path

--- a/tests/test_mlx_alt_text.py
+++ b/tests/test_mlx_alt_text.py
@@ -6,7 +6,8 @@ from mlx_alt_text import AltTextGenerator
 
 # This model is ~512MB
 # https://huggingface.co/mlx-community/SmolVLM-256M-Instruct-bf16
-TINY_MODEL = "mlx-community/SmolVLM-256M-Instruct-bf16"
+# TODO This model must be downloaded and available for these tests to work
+TINY_MODEL = "~/.cache/huggingface/hub/models--mlx-community--SmolVLM-256M-Instruct-bf16/snapshots/cfe17933371986666073f450510d9e40d6157b13"
 TINY_IMAGE = Path("tests/penguin-image.png")
 
 


### PR DESCRIPTION
I separated the download functionality into a separate `model_util` file because I wanted to keep the focus of the `AltTextGenerator` class to be on using the models to generate good alt text, not things that are extraneous to that.

The command line access to being able to download files, has also been separated, and in the process the alt text generation was also moved to a new sub command called `generate`.